### PR TITLE
fix: tweak macOS conditional for Byte typedef

### DIFF
--- a/src/gzip/zconf.h
+++ b/src/gzip/zconf.h
@@ -215,7 +215,7 @@
 #   define FAR
 #endif
 
-#if !defined(MACOS) && !defined(TARGET_OS_MAC)
+#if !defined(__MACTYPES__)
 typedef unsigned char  Byte;  /* 8 bits */
 #endif
 typedef unsigned int   uInt;  /* 16 bits or more */


### PR DESCRIPTION
Similar to what was done in crawl/crawl-zlib#2, this resolves an issue with the improper target conditionals being used that was recently uncovered due to a change in LLVM behavior and/or updates in the latest command line tools for macOS.

This is the same fix as what was mentioned in [freetype's tracker](https://gitlab.freedesktop.org/freetype/freetype/-/issues/1294) as well as what was done in the much larger commit (which I am _not_ going to try to cherrypick), [`3aeabbf`](https://gitlab.freedesktop.org/freetype/freetype/-/commit/3aeabbf).

This plus crawl/crawl-libpng#2 hould be enough to fix (maybe) crawl/crawl#4520.